### PR TITLE
Adds Http Client With Retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,71 @@
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# http-client-retry
+## Overview
+
+### US Link
+(Link to the US of jira process)
+
+### Type of change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [X] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Refactoring
+- [ ] This change requires a documentation update
+
+### What is the solution?
+1. Use `setRetryHandler` to define the maximum number of retries
+1. Use `setServiceUnavailableRetryStrategy` to configure the waiting time
+between request to avoid overflowing the client with calls, this can be configured to use an incrementing
+time between calls
+
+### What are the main changes this MR?
+1. Changes the Apache Http client in order to allow retries and time between retries.
+1. Adds Cucumber tests for multiple scenarios
+
+## Reviewing
+
+### Which order of files makes the most sense for the reviewer?
+1. `src/test/resources/httpRetry.feature`
+1. `HttpFactory.java`
+
+## Other Notes
+1. Take a look into the `src/test/resources/httpRetry.feature` to see the scenarios specified
+they include: 
+    * retry until success
+    * retry leads into failure
+    * success at first try
+1. Cucumber tests steps implemented using lambdas
+1. Timeouts not configured for each step
+1. In order to make timeout incremental with each retry we should use
+`setServiceUnavailableRetryStrategy::retryRequest` to increment a new variable on
+the `setServiceUnavailableRetryStrategy` and return it on `setServiceUnavailableRetryStrategy::getRetryInterval`.
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>HttpClient</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <java.version>11</java.version>
+        <cucumber.version>6.9.0</cucumber.version>
+    </properties>
+
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>1.58</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java8</artifactId>
+            <version>${cucumber.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit</artifactId>
+            <version>${cucumber.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/client/HttpFactory.java
+++ b/src/main/java/client/HttpFactory.java
@@ -1,0 +1,33 @@
+package client;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.ServiceUnavailableRetryStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.protocol.HttpContext;
+
+import java.util.concurrent.TimeUnit;
+
+public class HttpFactory {
+    public HttpClient httpClient(final int maxRetries,
+                                 final int configuredInitialWaitPeriod,
+                                 final int configuredTimeout)  {
+
+        return HttpClientBuilder.create()
+                .setConnectionTimeToLive(configuredTimeout, TimeUnit.SECONDS)
+                .setRetryHandler((exception, executionCount, context) -> executionCount <= maxRetries)
+                .setServiceUnavailableRetryStrategy(new ServiceUnavailableRetryStrategy() {
+                    @Override
+                    public boolean retryRequest(HttpResponse response, int executionCount, HttpContext context) {
+                        return executionCount <= maxRetries &&
+                                response.getStatusLine().getStatusCode() >= 500;
+                    }
+
+                    @Override
+                    public long getRetryInterval() {
+                        return configuredInitialWaitPeriod;
+                    }
+                })
+                .build();
+    }
+}

--- a/src/test/java/client/HttpRetryStep.java
+++ b/src/test/java/client/HttpRetryStep.java
@@ -1,0 +1,115 @@
+package client;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.cucumber.java8.En;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Scanner;
+import java.util.stream.IntStream;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.Assert.assertEquals;
+
+public class HttpRetryStep implements En {
+
+    private final int port = 18089;
+    private HttpClient httpClient;
+    private String state;
+    private String result;
+    private WireMockServer wireMockServer;
+
+    public HttpRetryStep() throws URISyntaxException {
+        final String httpScheme = "http";
+        final String localHost = "localhost";
+        final String testResource = "/my/resource";
+        final String scenario = "retryScenario";
+        final URI uri = new URIBuilder()
+                .setScheme(httpScheme)
+                .setHost(localHost)
+                .setPort(port)
+                .setPath(testResource)
+                .build();
+
+        setup();
+
+        Given("I have a http client with {int} number of retries", (Integer retries) -> {
+            httpClient = new HttpFactory()
+                    .httpClient(retries, 1000, 1000);
+        });
+
+        When("i fail {int} with {int} and {string}", (Integer numberFails, Integer httpCode, String body) -> {
+            IntStream.rangeClosed(1, numberFails).forEach( i -> {
+                String value = String.format("%d time requested", i);
+                wireMockServer.stubFor(get(urlEqualTo(testResource)).inScenario(scenario)
+                        .whenScenarioStateIs(state)
+                        .willSetStateTo(value)
+                        .willReturn(
+                                aResponse()
+                                        .withStatus(httpCode)
+                                        .withBody(body)
+                        ));
+                state = value;
+            });
+        });
+
+        When("have success with {string}", (String body) -> {
+            wireMockServer.stubFor(get(urlEqualTo(testResource)).inScenario(scenario)
+                    .whenScenarioStateIs(state)
+                    .willSetStateTo("finish")
+                    .willReturn(
+                            aResponse()
+                                    .withStatus(200)
+                                    .withBody("success")
+                    ));
+            result = convertHttpResponseToString(httpClient.execute(new HttpGet(uri)));
+        });
+
+        When("have failure with {string}", (String string) -> {
+            wireMockServer.stubFor(get(urlEqualTo(testResource)).inScenario(scenario)
+                    .whenScenarioStateIs(state)
+                    .willSetStateTo("finish")
+                    .willReturn(
+                            aResponse()
+                                    .withStatus(500)
+                                    .withBody(string)
+                    ));
+            result = convertHttpResponseToString(httpClient.execute(new HttpGet(uri)));
+        });
+
+        Then("the result should be {string}", (String expected) -> {
+            assertEquals(expected, result);
+        });
+
+        Then("endpoint should be called {int} times", (Integer expectedNumberOfCalls) -> {
+            wireMockServer.verify(expectedNumberOfCalls, getRequestedFor(urlEqualTo(testResource)));
+        });
+    }
+
+    private void setup() {
+        Before(() -> {
+            wireMockServer = new WireMockServer(port);
+            wireMockServer.start();
+        });
+
+        After(() -> wireMockServer.stop());
+    }
+
+    private String convertHttpResponseToString(HttpResponse httpResponse) throws IOException {
+        InputStream inputStream = httpResponse.getEntity().getContent();
+        return convertInputStreamToString(inputStream);
+    }
+
+    private String convertInputStreamToString(InputStream inputStream) {
+        Scanner scanner = new Scanner(inputStream, "UTF-8");
+        String string = scanner.useDelimiter("\\Z").next();
+        scanner.close();
+        return string;
+    }
+}

--- a/src/test/java/client/HttpRetryTest.java
+++ b/src/test/java/client/HttpRetryTest.java
@@ -1,0 +1,14 @@
+package client;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = {"classpath:httpRetry.feature"},
+        glue = "client",
+        plugin = {"pretty", "json:target/reports/json/day1.json"}
+)
+public class HttpRetryTest {
+}

--- a/src/test/resources/httpRetry.feature
+++ b/src/test/resources/httpRetry.feature
@@ -1,0 +1,29 @@
+Feature: Http Retries
+    As a developer
+    I want to retry when a http call has problems
+    So that I can have a more resilient call to the client
+
+    Scenario Outline: Retries after failure will result in success
+        Given I have a http client with <numberRetries> number of retries
+        When i fail <numberFails> with <failHttpCode> and <failureBody>
+            And have success with <successBody>
+        Then the result should be <result>
+            And endpoint should be called <numberCalls> times
+
+        Examples:
+            | numberRetries | numberFails | failHttpCode  | failureBody   | successBody   | numberCalls | result    |
+            | 3             | 2           | 500           | "failure"     | "success"     | 3           | "success" |
+            | 0             | 0           | 500           | "failure"     | "success"     | 1           | "success" |
+
+    Scenario Outline: Retries will lead to failure
+        Given I have a http client with <numberRetries> number of retries
+        When i fail <numberFails> with <failHttpCode> and <failureBody>
+            And have failure with <body>
+        Then the result should be <result>
+            And endpoint should be called <numberCalls> times
+
+        Examples:
+            | numberRetries | numberFails | failHttpCode  | failureBody   | body       | numberCalls | result    |
+            | 3             | 3           | 500           | "failure"     | "failure"  | 4           | "failure" |
+            | 0             | 0           | 500           | "failure"     | "failure"  | 1           | "failure" |
+


### PR DESCRIPTION
## Overview

### US Link
(Link to the US of jira process)

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring
- [ ] This change requires a documentation update

### What is the solution?
1. Use `setRetryHandler` to define the maximum number of retries
1. Use `setServiceUnavailableRetryStrategy` to configure the waiting time
between request to avoid overflowing the client with calls, this can be configured to use an incrementing
time between calls

### What are the main changes this MR?
1. Changes the Apache Http client in order to allow retries and time between retries.
1. Adds Cucumber tests for multiple scenarios

## Reviewing

### Which order of files makes the most sense for the reviewer?
1. `src/test/resources/httpRetry.feature`
1. `HttpFactory.java`

## Other Notes
1. Take a look into the `src/test/resources/httpRetry.feature` to see the scenarios specified
they include: 
    * retry until success
    * retry leads into failure
    * success at first try
1. Cucumber tests steps implemented using lambdas
1. Timeouts not configured for each step
1. In order to make timeout incremental with each retry we should use
`setServiceUnavailableRetryStrategy::retryRequest` to increment a new variable on
the `setServiceUnavailableRetryStrategy` and return it on `setServiceUnavailableRetryStrategy::getRetryInterval`.

